### PR TITLE
Enable checking of a whole package at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Branch coverage measurement tool for golang.
 ## Install and Usage
 ```text
 $ go get github.com/junhwi/gobco
+
 $ ./gobco sample/foo.go
-$ gobco sample/foo.go
 --- FAIL: TestFoo (0.00s)
     foo_test.go:7: wrong
 FAIL
 Branch coverage: 5/6
-sample/foo.go:10:5: branch "Bar(a) == 10" was never true
+sample/foo.go:10:5: condition "Bar(a) == 10" was never true
 exit status 1
 FAIL    github.com/junhwi/gobco/sample  0.112s
 exit status 1

--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 Branch coverage measurement tool for golang.
 
 ## Install and Usage
-```sh
+```text
 $ go get github.com/junhwi/gobco
 $ ./gobco sample/foo.go
+$ gobco sample/foo.go
 --- FAIL: TestFoo (0.00s)
-  foo_test.go:16: wrong
+    foo_test.go:7: wrong
 FAIL
-Coverage: 5 / 6
+Branch coverage: 5/6
+sample/foo.go:10:5: branch "Bar(a) == 10" was never true
 exit status 1
-FAIL  go-cov/sample 0.008s
+FAIL    github.com/junhwi/gobco/sample  0.112s
+exit status 1
 ```

--- a/main.go
+++ b/main.go
@@ -6,17 +6,209 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
-var branchId int
+type branch struct {
+	start      string // human-readable position in the file, e.g. main.go:17:13
+	code       string // the code for the condition of the branch
+	trueCount  int
+	falseCount int
+}
 
-func getBranchId() int {
-	ret := branchId
-	branchId++
-	return ret
+type instrumenter struct {
+	fset     *token.FileSet
+	text     string   // during instrument(), the text of the current file
+	branches []branch // the collected branches from all files from fset
+}
+
+func (i *instrumenter) addBranch(start, code string) int {
+	i.branches = append(i.branches, branch{start, code, 0, 0})
+	return len(i.branches) - 1
+}
+
+func (i *instrumenter) newCounter(cond ast.Expr) *ast.CallExpr {
+	start := i.fset.Position(cond.Pos())
+	code := i.text[start.Offset:i.fset.Position(cond.End()).Offset]
+	branchIdx := i.addBranch(start.String(), code)
+
+	return &ast.CallExpr{
+		Fun: ast.NewIdent("gobcoCover"),
+		Args: []ast.Expr{
+			cond,
+			&ast.BasicLit{
+				Kind:  token.INT,
+				Value: fmt.Sprint(branchIdx),
+			},
+		},
+	}
+}
+
+func (i *instrumenter) visit(n ast.Node) bool {
+	switch x := n.(type) {
+	// TODO: We need to handle ast.CaseClause if it is bool
+	// TODO: We need to handle go routine related things
+	// such as ast.SelectStmt
+	case *ast.IfStmt:
+		x.Cond = i.newCounter(x.Cond)
+	case *ast.ForStmt:
+		if x.Cond != nil {
+			x.Cond = i.newCounter(x.Cond)
+		}
+	}
+	return true
+}
+
+func (i *instrumenter) instrument(arg string, isDir bool) {
+	// Create the AST by parsing src.
+	i.fset = token.NewFileSet() // positions are relative to fset
+
+	dir := arg
+	if !isDir {
+		dir = filepath.Dir(dir)
+	}
+
+	pkgs, err := parser.ParseDir(i.fset, dir, func(info os.FileInfo) bool {
+		if isDir {
+			return !strings.HasSuffix(info.Name(), "_test.go")
+		} else {
+			return info.Name() == path.Base(filepath.ToSlash(arg))
+		}
+	}, 0)
+	check(err)
+
+	for _, pkg := range pkgs {
+		var filenames []string
+		for filename := range pkg.Files {
+			filenames = append(filenames, filename)
+		}
+		sort.Strings(filenames)
+
+		for _, filename := range filenames {
+			fileBytes, err := ioutil.ReadFile(filename)
+			check(err)
+			i.text = string(fileBytes)
+
+			ast.Inspect(pkg.Files[filename], i.visit)
+
+			err = os.Rename(filename, filename+".gobco.tmp")
+			check(err)
+
+			fd, err := os.Create(filename)
+			check(err)
+			err = printer.Fprint(fd, i.fset, pkg.Files[filename])
+			check(err)
+			err = fd.Close()
+			check(err)
+		}
+	}
+
+pkg:
+	for pkgname, pkg := range pkgs {
+		for filename := range pkg.Files {
+			i.writeGobcoTest(filepath.Join(filepath.Dir(filename), "gobco_test.go"), pkgname)
+			break pkg
+		}
+	}
+}
+
+func (i *instrumenter) writeGobcoTest(filename, pkgname string) {
+	f, err := os.Create(filename)
+	check(err)
+
+	fmt.Fprintf(f, "package %s\n", pkgname)
+	f.WriteString(`
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+type gobcoBranch struct {
+	start      string
+	code       string
+	trueCount  int
+	falseCount int
+}
+
+func gobcoCover(cond bool, idx int) bool {
+  if cond {
+    gobcoBranches[idx].trueCount++
+  } else {
+    gobcoBranches[idx].falseCount++
+  }
+  return cond
+}
+
+func gobcoPrintCoverage() {
+  cnt := 0
+  for _, c := range gobcoBranches {
+    if c.trueCount > 0 {
+      cnt++
+    }
+    if c.falseCount > 0 {
+      cnt++
+    }
+  }
+  fmt.Printf("Branch coverage: %d/%d\n", cnt, len(gobcoBranches)*2)
+
+  for _, branch := range gobcoBranches {
+    if branch.trueCount == 0 {
+      fmt.Printf("%s: branch %q was never true\n", branch.start, branch.code)
+    }
+    if branch.falseCount == 0 {
+      fmt.Printf("%s: branch %q was never false\n", branch.start, branch.code)
+    }
+  }
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	exitCode := m.Run()
+    gobcoPrintCoverage()
+    os.Exit(exitCode)
+}
+`)
+
+	fmt.Fprintln(f, `var gobcoBranches = [...]gobcoBranch{`)
+	for _, branch := range i.branches {
+		fmt.Fprintf(f, "\t{%q, %q, 0, 0},\n", branch.start, branch.code)
+	}
+	fmt.Fprintln(f, "}")
+
+	err = f.Close()
+	check(err)
+}
+
+// recover original files
+//
+// TODO: leave this cleanup procedure as optional with --work flag
+func (i *instrumenter) cleanUp(arg string) {
+	i.fset.Iterate(func(file *token.File) bool {
+		filename := file.Name()
+		err := os.Remove(filename)
+		check(err)
+		err = os.Rename(filename+".gobco.tmp", filename)
+		check(err)
+
+		return true
+	})
+
+	i.fset.Iterate(func(file *token.File) bool {
+		err := os.Remove(filepath.Join(filepath.Dir(file.Name()), "gobco_test.go"))
+		check(err)
+
+		return false
+	})
 }
 
 func check(e error) {
@@ -25,115 +217,30 @@ func check(e error) {
 	}
 }
 
-func newCounter(cond ast.Expr) *ast.CallExpr {
-	return &ast.CallExpr{
-		Fun: ast.NewIdent("inst"),
-		Args: []ast.Expr{
-			cond,
-			&ast.BasicLit{
-				Kind:  token.INT,
-				Value: fmt.Sprint(getBranchId()),
-			},
-		},
-	}
-}
-
-func visit(n ast.Node) bool {
-	switch x := n.(type) {
-	// TODO: We need to handle ast.CaseCluase
-	// TODO: We need to handle go routine related things
-	// such as ast.SelectStmt
-	case *ast.IfStmt:
-		x.Cond = newCounter(x.Cond)
-	case *ast.ForStmt:
-		x.Cond = newCounter(x.Cond)
-	}
-	return true
-}
-
-func instrument(name string) {
-	// Create the AST by parsing src.
-	fset := token.NewFileSet() // positions are relative to fset
-	f, err := parser.ParseFile(fset, name, nil, 0)
-	if err != nil {
-		panic(err)
-	}
-	fmtImport := &ast.ImportSpec{
-		Path: &ast.BasicLit{
-			Kind:  token.STRING,
-			Value: fmt.Sprintf("%q", "fmt"),
-		},
-	}
-	f.Imports = append(f.Imports, fmtImport)
-	f.Decls = append([]ast.Decl{&ast.GenDecl{
-		Tok: token.IMPORT,
-		Specs: []ast.Spec{
-			fmtImport,
-		},
-	}}, f.Decls...)
-	// Inspect the AST and print all identifiers and literals.
-	ast.Inspect(f, visit)
-	//ast.Print(fset, f)
-
-	//fd := os.Stdout
-	cmd := exec.Command("mv", name, name+".tmp")
-	err = cmd.Run()
-	check(err)
-	fd, err := os.Create(name)
-	check(err)
-	printer.Fprint(fd, fset, f)
-	fmt.Fprintf(fd, `
-func inst(cond bool, idx int) bool {
-  if cond {
-    Cov.tCount[idx] = 1
-  } else {
-    Cov.fCount[idx] = 1
-  }
-  return cond
-}
-
-func PrintCoverage() {
-  cnt := 0
-  for _, c := range Cov.tCount {
-    if c == 1 {
-      cnt++
-    }
-  }
-  for _, c := range Cov.fCount {
-    if c == 1 {
-      cnt++
-    }
-  }
-  fmt.Println("Branch Coverage:", cnt, "/", len(Cov.tCount)*2)
-}
-
-var Cov = struct {
-  tCount [%d]int
-  fCount [%d]int
-}{}
-  `, branchId, branchId)
-}
-
 func main() {
 
-	// Parse the flag and get file name
+	// Parse the flag and get file or directory name
+	arg := os.Args[1]
+	st, err := os.Stat(arg)
+	isDir := err == nil && st.Mode().IsDir()
 
-	// instrument
-	instrument(os.Args[1])
-	// move original file to temporary
+	// move original files to temporary and instrument the files
+	instrumenter := &instrumenter{}
+	instrumenter.instrument(arg, isDir)
+
 	// run go test
-	err := os.Chdir(filepath.Dir(os.Args[1]))
-	check(err)
-	out, _ := exec.Command("go", "test").Output()
-	fmt.Printf("%s\n", out)
+	goTest := exec.Command("go", "test", "-vet=off")
+	goTest.Stdout = os.Stdout
+	goTest.Stderr = os.Stderr
+	goTest.Dir = arg
+	if !isDir {
+		goTest.Dir = filepath.Dir(goTest.Dir)
+	}
 
-	// recover original file and clean up
-	fname := filepath.Base(os.Args[1])
-	cmd := exec.Command("rm", fname)
-	err = cmd.Run()
-	check(err)
-	cmd = exec.Command("mv", fname+".tmp", fname)
-	err = cmd.Run()
-	check(err)
-	// TODO: leave this cleanup procedure as optional with --work flag
+	err = goTest.Run()
+	if err != nil {
+		log.Println(err)
+	}
+
+	instrumenter.cleanUp(arg)
 }

--- a/main.go
+++ b/main.go
@@ -79,6 +79,13 @@ func (i *instrumenter) visit(n ast.Node) bool {
 
 	case *ast.AssignStmt:
 		i.visitExprs(n.Rhs)
+
+	case *ast.SwitchStmt:
+		if n.Tag == nil {
+			for _, body := range n.Body.List {
+				i.visitExprs(body.(*ast.CaseClause).List)
+			}
+		}
 	}
 	return true
 }

--- a/main.go
+++ b/main.go
@@ -54,19 +54,29 @@ func (i *instrumenter) visit(n ast.Node) bool {
 	// TODO: We need to handle ast.CaseClause if it is bool
 	// TODO: We need to handle go routine related things
 	// such as ast.SelectStmt
+
 	case *ast.IfStmt:
 		n.Cond = i.newCounter(n.Cond)
+
 	case *ast.ForStmt:
 		if n.Cond != nil {
 			n.Cond = i.newCounter(n.Cond)
 		}
+
 	case *ast.BinaryExpr:
 		if n.Op == token.LAND || n.Op == token.LOR {
 			n.X = i.newCounter(n.X)
 			n.Y = i.newCounter(n.Y)
 		}
+
+	case *ast.CallExpr:
+		if ident, ok := n.Fun.(*ast.Ident); !ok || ident.Name != "gobcoCover" {
+			i.visitExprs(n.Args)
+		}
+
 	case *ast.ReturnStmt:
 		i.visitExprs(n.Results)
+
 	case *ast.AssignStmt:
 		i.visitExprs(n.Rhs)
 	}

--- a/main.go
+++ b/main.go
@@ -17,10 +17,8 @@ import (
 )
 
 type branch struct {
-	start      string // human-readable position in the file, e.g. main.go:17:13
-	code       string // the code for the condition of the branch
-	trueCount  int
-	falseCount int
+	start string // human-readable position in the file, e.g. main.go:17:13
+	code  string // the code for the condition of the branch
 }
 
 type instrumenter struct {
@@ -30,7 +28,7 @@ type instrumenter struct {
 }
 
 func (i *instrumenter) addBranch(start, code string) int {
-	i.branches = append(i.branches, branch{start, code, 0, 0})
+	i.branches = append(i.branches, branch{start, code})
 	return len(i.branches) - 1
 }
 

--- a/main.go
+++ b/main.go
@@ -193,11 +193,19 @@ func gobcoPrintCoverage() {
 	fmt.Printf("Branch coverage: %d/%d\n", cnt, len(gobcoConds)*2)
 
 	for _, cond := range gobcoConds {
-		if cond.trueCount == 0 {
-			fmt.Printf("%s: condition %q was never true\n", cond.start, cond.code)
-		}
-		if cond.falseCount == 0 {
-			fmt.Printf("%s: condition %q was never false\n", cond.start, cond.code)
+		switch {
+		case cond.trueCount == 0 && cond.falseCount > 1:
+			fmt.Printf("%s: condition %q was %d times false but never true\n", cond.start, cond.code, cond.falseCount)
+		case cond.trueCount == 0 && cond.falseCount == 1:
+			fmt.Printf("%s: condition %q was once false but never true\n", cond.start, cond.code)
+
+		case cond.falseCount == 0 && cond.trueCount > 1:
+			fmt.Printf("%s: condition %q was %d times true but never false\n", cond.start, cond.code, cond.trueCount)
+		case cond.falseCount == 0 && cond.trueCount == 1:
+			fmt.Printf("%s: condition %q was once true but never false\n", cond.start, cond.code)
+
+		case cond.trueCount == 0 && cond.falseCount == 0:
+			fmt.Printf("%s: condition %q was never evaluated", cond.start, cond.code)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -139,41 +139,41 @@ type gobcoBranch struct {
 }
 
 func gobcoCover(cond bool, idx int) bool {
-  if cond {
-    gobcoBranches[idx].trueCount++
-  } else {
-    gobcoBranches[idx].falseCount++
-  }
-  return cond
+	if cond {
+		gobcoBranches[idx].trueCount++
+	} else {
+		gobcoBranches[idx].falseCount++
+	}
+	return cond
 }
 
 func gobcoPrintCoverage() {
-  cnt := 0
-  for _, c := range gobcoBranches {
-    if c.trueCount > 0 {
-      cnt++
-    }
-    if c.falseCount > 0 {
-      cnt++
-    }
-  }
-  fmt.Printf("Branch coverage: %d/%d\n", cnt, len(gobcoBranches)*2)
+	cnt := 0
+	for _, c := range gobcoBranches {
+		if c.trueCount > 0 {
+			cnt++
+		}
+		if c.falseCount > 0 {
+			cnt++
+		}
+	}
+	fmt.Printf("Branch coverage: %d/%d\n", cnt, len(gobcoBranches)*2)
 
-  for _, branch := range gobcoBranches {
-    if branch.trueCount == 0 {
-      fmt.Printf("%s: branch %q was never true\n", branch.start, branch.code)
-    }
-    if branch.falseCount == 0 {
-      fmt.Printf("%s: branch %q was never false\n", branch.start, branch.code)
-    }
-  }
+	for _, branch := range gobcoBranches {
+		if branch.trueCount == 0 {
+			fmt.Printf("%s: branch %q was never true\n", branch.start, branch.code)
+		}
+		if branch.falseCount == 0 {
+			fmt.Printf("%s: branch %q was never false\n", branch.start, branch.code)
+		}
+	}
 }
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	exitCode := m.Run()
-    gobcoPrintCoverage()
-    os.Exit(exitCode)
+	gobcoPrintCoverage()
+	os.Exit(exitCode)
 }
 `)
 

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,9 @@ func CoverTest(a int, b string) bool {
 			return true
 		}
 	}
+	if len(b) > 5 {
+		return len(b) > 10
+	}
 	return false
 }`, "\n")
 
@@ -39,18 +42,21 @@ package main
 import "fmt"
 
 func CoverTest(a int, b string) bool {
-	if gobcoCover(a > 0 && b == "positive", 0) {
+	if gobcoCover(0, gobcoCover(1, a > 0) && gobcoCover(2, b == "positive")) {
 		return true
 	}
 	for i, r := range b {
-		if gobcoCover(r == a, 1) {
+		if gobcoCover(3, r == a) {
 			return true
 		}
 	}
-	for i := 0; gobcoCover(i < len(b), 2); i++ {
-		if gobcoCover(b[i] == a, 3) {
+	for i := 0; gobcoCover(4, i < len(b)); i++ {
+		if gobcoCover(5, b[i] == a) {
 			return true
 		}
+	}
+	if gobcoCover(6, len(b) > 5) {
+		return gobcoCover(7, len(b) > 10)
 	}
 	return false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func Test_instrumenter_visit(t *testing.T) {
+
+	code := strings.TrimLeft(`
+package main
+
+import "fmt"
+
+func CoverTest(a int, b string) bool {
+	if a > 0 && b == "positive" {
+		return true
+	}
+	for i, r := range b {
+		if r == a {
+			return true
+		}
+	}
+	for i := 0; i < len(b); i++ {
+		if b[i] == a {
+			return true
+		}
+	}
+	return false
+}`, "\n")
+
+	expected := strings.TrimLeft(`
+package main
+
+import "fmt"
+
+func CoverTest(a int, b string) bool {
+	if gobcoCover(a > 0 && b == "positive", 0) {
+		return true
+	}
+	for i, r := range b {
+		if gobcoCover(r == a, 1) {
+			return true
+		}
+	}
+	for i := 0; gobcoCover(i < len(b), 2); i++ {
+		if gobcoCover(b[i] == a, 3) {
+			return true
+		}
+	}
+	return false
+}
+`, "\n")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", code, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := instrumenter{fset, code, nil}
+	ast.Inspect(f, i.visit)
+
+	var out strings.Builder
+	err = printer.Fprint(&out, fset, f)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if out.String() != expected {
+		t.Errorf("\nexp: %q\nact: %q", expected, out.String())
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -16,22 +16,58 @@ package main
 
 import "fmt"
 
-func CoverTest(a int, b string) bool {
-	if a > 0 && b == "positive" {
-		return true
+func declarations(i int) {
+	_ = i > 0
+	pos := i > 0
+	_ = pos
+}
+
+func switchStmt(s string) {
+	switch s {
+	case "one":
 	}
+
+	switch {
+	case s == "one":
+	case s < "a":
+	}
+}
+
+func booleanOperators(a, b bool) {
+	both := a && b
+	either := a || b
+	_, _ = both, either
+}
+
+func forStmt(s string) bool {
 	for i, r := range b {
 		if r == a {
 			return true
 		}
 	}
+
 	for i := 0; i < len(b); i++ {
 		if b[i] == a {
 			return true
 		}
 	}
+
+	return false
+}
+
+func ifStmt(a int, b string) bool {
+	if a > 0 && b == "positive" {
+		return true
+	}
 	if len(b) > 5 {
 		return len(b) > 10
+	}
+	return false
+}
+
+func callExpr(a bool, b string) bool {
+	if len(b) > 0 {
+		return callExpr(len(b) % 2 == 0, b[1:])
 	}
 	return false
 }`, "\n")
@@ -41,22 +77,58 @@ package main
 
 import "fmt"
 
-func CoverTest(a int, b string) bool {
-	if gobcoCover(0, gobcoCover(1, a > 0) && gobcoCover(2, b == "positive")) {
+func declarations(i int) {
+	_ = gobcoCover(0, i > 0)
+	pos := gobcoCover(1, i > 0)
+	_ = pos
+}
+
+func switchStmt(s string) {
+	switch s {
+	case "one":
+	}
+
+	switch {
+	case gobcoCover(2, s == "one"):
+	case gobcoCover(3, s < "a"):
+	}
+}
+
+func booleanOperators(a, b bool) {
+	both := gobcoCover(4, a) && gobcoCover(5, b)
+	either := gobcoCover(6, a) || gobcoCover(7, b)
+	_, _ = both, either
+}
+
+func forStmt(s string) bool {
+	for i, r := range b {
+		if gobcoCover(8, r == a) {
+			return true
+		}
+	}
+
+	for i := 0; gobcoCover(9, i < len(b)); i++ {
+		if gobcoCover(10, b[i] == a) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ifStmt(a int, b string) bool {
+	if gobcoCover(11, gobcoCover(12, a > 0) && gobcoCover(13, b == "positive")) {
 		return true
 	}
-	for i, r := range b {
-		if gobcoCover(3, r == a) {
-			return true
-		}
+	if gobcoCover(14, len(b) > 5) {
+		return gobcoCover(15, len(b) > 10)
 	}
-	for i := 0; gobcoCover(4, i < len(b)); i++ {
-		if gobcoCover(5, b[i] == a) {
-			return true
-		}
-	}
-	if gobcoCover(6, len(b) > 5) {
-		return gobcoCover(7, len(b) > 10)
+	return false
+}
+
+func callExpr(a bool, b string) bool {
+	if gobcoCover(16, len(b) > 0) {
+		return callExpr(gobcoCover(17, len(b)%2 == 0), b[1:])
 	}
 	return false
 }

--- a/sample/foo_test.go
+++ b/sample/foo_test.go
@@ -1,18 +1,9 @@
 package main
 
-import (
-  "os"
-  "testing"
-)
-
-func TestMain(m *testing.M) {
-  retCode := m.Run()
-  PrintCoverage()
-  os.Exit(retCode)
-}
+import "testing"
 
 func TestFoo(t *testing.T) {
-  if !Foo(9) {
-    t.Error("wrong")
-  }
+	if !Foo(9) {
+		t.Error("wrong")
+	}
 }


### PR DESCRIPTION
* allow directory as command line argument

* provide a detailed list about missed branches

* avoid the need for calling PrintCoverage explicitly
  in the tested code

* replace exec.Command with simple filesystem operations
  (to make gobco portable to Windows)

* move all identifiers into gobco namespace
  (to avoid possible name collisions with "inst" or "Cov")

* close files after writing them
  (Windows doesn't like files that are still open)

* mark temporary files clearly as gobco files